### PR TITLE
Feature default nettype pair

### DIFF
--- a/verilog.md
+++ b/verilog.md
@@ -1,5 +1,5 @@
 
-add to begin in every sythezable verilog file to raising error if signal type not defined well:
+add to the begin in every synthesizable verilog file to raising an error if signal type not defined well:
 
 ```
 `default_nettype none

--- a/verilog.md
+++ b/verilog.md
@@ -4,3 +4,9 @@ add to the begin in every synthesizable verilog file to raising an error if sign
 ```
 `default_nettype none
 ```
+
+add to the end in every synthesizable verilog file for leave external modules untouchable:
+
+```
+`default_nettype wire
+```


### PR DESCRIPTION
Add a "close" default_nettype wire.
`default_nettype works across all modules processed by tool after it is presented. 
So if any other modules think that the default nettype is wire the module will be broken. Often presented into Xilinx IP cores.